### PR TITLE
Add content to food & Sheffield pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/dfe-stats-awayday-2025.github.io.Rproj
+++ b/dfe-stats-awayday-2025.github.io.Rproj
@@ -1,0 +1,13 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX

--- a/pages/Food/Food.html
+++ b/pages/Food/Food.html
@@ -18,8 +18,24 @@
   <a href="https://matthewberobinson.github.io/dfe-stats-awayday-2025.github.io/pages/Advertising/Advertising.html">Advertising</a>
 </div>
 
-<div  style="margin-left: 200px;">
-<a href="https://sheffield.ac.uk/cafesandbars/wave-kitchen">Eat at The Wave</a>
-<br>
-<a href="https://sheffield.ac.uk/cafesandbars/cafes">Food on Campus</a>
+<div style="margin-left: 200px; padding: 20px;">
+  <h2>Lunch 🥪</h1>
+  <p>As you all know, there are currently budgetary restrictions on all awaydays and events. We were determined to find a way to put on the GSS awayday again this year after such a successful day in 2024, but this means we have some restrictions on what we can do.</p>
+  <p>The government is currently not allowing any spend on catering for events like this, and so our hands are unfortunately tied. We didn’t think this should affect the day we have planned as the agenda is going absolutely jam packed full of valuable and fun sessions!</p>
+  <p><strong>So what does this mean for you?</strong></p>
+  <ul>
+    <li>If you are not Sheffield based, you will be able to claim T&amp;S in line with the department's policy: <a href="https://educationgovuk.sharepoint.com/sites/travel-and-expenses/SitePages/claim.aspx#how-much-you-can-claim-for-subsistence">Claim expenses</a></li>
+    <li>Unfortunately, if you are Sheffield based, the venue is not over 10 miles from your workplace (which is the minimum distance for claims <a href="https://educationgovuk.sharepoint.com/:w:/r/sites/travel-and-expenses/_layouts/15/Doc.aspx?sourcedoc=%7B7F87AB14-DE7E-4F79-B669-199BA8672DEA%7D&file=travel-and-expenses-policy.docx&wdLOR=c508B9ED3-E364-4412-BC99-1E98E39D9A83&action=default&mobileredirect=true"> as outlined in the guidance</a>) and so Sheffield-ers will not be able to claim for lunch. I’ve raised this with the department's financial teams and had it reiterated that this is the guidance we must follow. Please make plans accordingly.</li>
+  </ul>
+  
+  <p>There are a number of nearby options for purchasing lunch, including the cafe inside the venue:</p>
+    <li><a href="https://sheffield.ac.uk/cafesandbars/wave-kitchen">Eat at The Wave</a></li>
+    <li><a href="https://sheffield.ac.uk/cafesandbars/cafes">Food on Campus</a></li>
+    
+<h3>Check out the nearby shop options:</h3>
+<iframe src="https://www.google.com/maps/embed?pb=!1m16!1m12!1m3!1d2850.916742032857!2d-1.497062222814997!3d53.3809153722993!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!2m1!1sshop!5e1!3m2!1sen!2suk!4v1754393097772!5m2!1sen!2suk" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+
+<h3>Check out the nearby cafes:</h3>
+<iframe src="https://www.google.com/maps/embed?pb=!1m16!1m12!1m3!1d2850.946306765541!2d-1.4960966275696352!3d53.3804737929466!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!2m1!1zY2Fmw6g!5e1!3m2!1sen!2suk!4v1754393222174!5m2!1sen!2suk" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
 </div>
+</html>

--- a/pages/Sheffield/Sheffield.html
+++ b/pages/Sheffield/Sheffield.html
@@ -17,3 +17,48 @@
   <a href="https://matthewberobinson.github.io/dfe-stats-awayday-2025.github.io/pages/Hackathon/Hackathon.html">Hackathon</a>
   <a href="https://matthewberobinson.github.io/dfe-stats-awayday-2025.github.io/pages/Advertising/Advertising.html">Advertising</a>
 </div>
+
+<div style="margin-left: 200px; padding: 20px;">
+  <h2>From the train station</h1>
+  <h3>Walking from the station</h3>
+ <p>To walk to the venue from the train station takes approximately 37-41 minutes using the below route options:</p>
+ 
+ <iframe
+  src="https://www.google.com/maps/embed?pb=!1m28!1m12!1m3!1d9474.745344914387!2d-1.4866791203801932!3d53.381093927629424!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m13!3e2!4m5!1s0x487982e61c71dd75%3A0xd40e1458262c0c25!2sSheffield%20Station!3m2!1d53.3772041!2d-1.461537!4m5!1s0x487982e5bb2ddcf5%3A0x5a935a4424c9e3c6!2sThe%20Wave%2C%20University%20of%20Sheffield!3m2!1d53.382567!2d-1.487616!5e0!3m2!1sen!2suk!4v1693407926387!5m2!1sen!2suk"
+  width="600"
+  height="450"
+  style="border:0;"
+  allowfullscreen=""
+  loading="lazy"
+  referrerpolicy="no-referrer-when-downgrade">
+</iframe>
+ <h3>Public transport from the station</h3>
+<p>To use public transport from the station, we recommend using the 51 bus route from Arundel Gate (Stop AG11). Alternative routes are available, 
+but some (like the 10a) drop you an approx 10 minute uphill walk from the venue, whereas the 51 drops you only 2 minutes away. Bus routes
+take from 23-30 minutes.</p>
+<a href="https://www.google.com/maps/dir/Sheffield+Station/The+Wave,+University+of+Sheffield/@53.379999,-1.475,14z/data=!4m2!4m1!3e3" target="_blank">
+  View bus route from Sheffield Station to The Wave
+</a>
+
+<h2>From the office</h2>
+<h3>Walking from the office</h3>
+<p>To walk to the venue from the office at St Pauls Place takes approximately 25-30 minutes using the below route options:</p>
+
+<iframe
+  src="https://www.google.com/maps/embed?pb=!1m28!1m12!1m3!1d9474.745344914387!2d-1.4866791203801932!3d53.381093927629424!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m13!3e2!4m5!1s0x487982f4e7499f1b%3A0x2f144bf9ea9d3607!2sSt%20Paul's%20Place%2C%20Sheffield!3m2!1d53.3777!2d-1.4708!4m5!1s0x487982e5bb2ddcf5%3A0x5a935a4424c9e3c6!2sThe%20Wave%2C%20University%20of%20Sheffield!3m2!1d53.382567!2d-1.487616!5e0!3m2!1sen!2suk!4v1693407926387!5m2!1sen!2suk"
+  width="600"
+  height="450"
+  style="border:0;"
+  allowfullscreen=""
+  loading="lazy"
+  referrerpolicy="no-referrer-when-downgrade">
+</iframe>
+<h3>Public transport from the office</h3>
+<p>To use public transport from the office, you can use the same route as from the station (the 51 from Arundel Gate stop AG11) or multiple 
+different routes from High Street stop HS4. These routes take on average 19-25 minutes.</p>
+<a href="https://www.google.com/maps/dir/St+Paul's+Place,+Sheffield/The+Wave,+University+of+Sheffield/@53.379999,-1.475,14z/data=!4m2!4m1!3e3" target="_blank">
+  View bus route from the office at St Paul's Place to The Wave
+</a>
+
+</div>
+</html>


### PR DESCRIPTION
**The food page**
Added information on lunch provisions, linking to relevant T&S guidance 
Embedded maps to local shops & cafes for food provision

**The Sheffield page**
Added instructions/maps for both walking and public transport from both the station and the office. Maps embedded for walking routes, links for bus routes with advise/recommended routes & estimates times. 